### PR TITLE
Add APPENDICES header to first appendix

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -23,15 +23,17 @@
 \usepackage{cleveref}
 \usepackage[]{algorithm2e}
 \usepackage{titlesec}
+\usepackage{ifthen}
 
 \makeindex
 \makeglossaries
 
 % Shrink the size of headers
 \titleformat{\chapter}[display]
-        {\normalfont\normalsize\centering}{\chaptertitlename\ \thechapter}{0pt}{\normalsize\uppercase}
-        \titlespacing*{\chapter}
-{0pt}{-20pt}{4.3ex plus .2ex}
+        {\normalfont\normalsize\centering}
+        {\ifthenelse{\equal{\thechapter}{A}}{APPENDICES\\[4.3ex]}{}\chaptertitlename\ \thechapter}
+        {0pt}{\normalsize\uppercase}
+\titlespacing*{\chapter}{0pt}{-20pt}{4.3ex plus .2ex}
 
 
 \titleformat*{\section}{\normalsize\bfseries}


### PR DESCRIPTION
Fixes #5. @Jdban can you see if this change works for you?

This is pretty messy; I'd prefer to have this handled in the style files, but by using `titlesec` we've now given over control of heading formatting.

Rendering:
![appendices](https://cloud.githubusercontent.com/assets/227091/15973240/28f765d0-2ef7-11e6-91f8-8ed0793a6162.png)
