### PR TITLE
Added hidelinks flag to hyperref usage to links are hidden

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -3,7 +3,7 @@
 \usepackage{etex}
 \usepackage[morefloats=125]{morefloats}
 \usepackage[hyphens]{url}
-\usepackage[breaklinks=true]{hyperref}
+\usepackage[breaklinks=true,hidelinks]{hyperref}
 \usepackage{subfig}
 \usepackage{graphicx}
 \usepackage{tabularx}


### PR DESCRIPTION
Some PDF readers make links make your paper look awful with these big ugly boxes around them. When I had my paper formatting reviewed, they told me to remove the usage of yellow and green and blue coloring from my paper which I was unaware of, and this was the cause. 

I enabled the hidelinks flag in the hyperref package in order to stop this from happening ([link here](http://tex.stackexchange.com/questions/823/remove-ugly-borders-around-clickable-cross-references-and-hyperlinks)).

Here is what my paper looked like before and after in one offending pdf reader:

Before:
<img src="http://i.imgur.com/kYml5dn.png" width="300">

After:
<img src="http://i.imgur.com/3xK8EDp.png" width="300">
