### PR TITLE
Rearrange committee titles

### DIFF
--- a/frontmatter.tex
+++ b/frontmatter.tex
@@ -3,8 +3,8 @@
 \degreemonth{June} \degreeyear{2014} \degree{Master of Science}
 \defensemonth{June} \defenseyear{2014}
 \numberofmembers{2}
-   \chair{Professor Alexander Dekhtyar, Ph.D. \linebreak Department of Computer Science}
-   \othermemberA{Associate Professor Aaron Keen, Ph.D. \linebreak Department of Computer Science}
-   \othermemberB{Professor Franz Kurfess, Ph.D. \linebreak Department of Computer Science}
+   \chair{Alexander Dekhtyar, Ph.D. \linebreak Professor of Computer Science}
+   \othermemberA{Aaron Keen, Ph.D. \linebreak Professor of Computer Science}
+   \othermemberB{Franz Kurfess, Ph.D. \linebreak Professor of Computer Science}
 \field{Computer Science} \campus{San Luis Obispo}
 \copyrightyears{seven}


### PR DESCRIPTION
Current style requires titles with departments instead of with names.

(Also, Dr. Keen has been promoted.)