### PR TITLE
Load hyperref after titlesec, set PDF metadata

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -3,7 +3,6 @@
 \usepackage{etex}
 \usepackage[morefloats=125]{morefloats}
 \usepackage[hyphens]{url}
-\usepackage[breaklinks=true,hidelinks]{hyperref}
 \usepackage{subfig}
 \usepackage{graphicx}
 \usepackage{tabularx}
@@ -23,6 +22,7 @@
 \usepackage{cleveref}
 \usepackage[]{algorithm2e}
 \usepackage{titlesec}
+\usepackage[breaklinks=true,hidelinks,pdfusetitle]{hyperref}
 \usepackage{ifthen}
 
 \makeindex


### PR DESCRIPTION
Here's one more change I made in [my thesis](http://digitalcommons.calpoly.edu/theses/1561/).

`hyperref` [has to be](http://tex.stackexchange.com/a/176156) loaded after `titlesec` so that links to sections that start new pages go to the right place.

Adding the `pdfusetitle` option puts the thesis title and author in PDF metadata.