### PR TITLE
Add period after last keyword

### DIFF
--- a/cpthesis.cls
+++ b/cpthesis.cls
@@ -459,7 +459,7 @@ ALL RIGHTS RESERVED
 \vfil\null
 \else
 \vspace*{\fill}
-{\keywordsname}: \@keywords
+{\keywordsname}: \@keywords.
 \vspace{0.5in}
 \fi
 \newpage


### PR DESCRIPTION
In a thesis formatting review, I was told you need a period after your keywords (though I don't see that as a requirement in the Masters Thesis Formatting Guidelines pdf). This is a one character change.

Before:

<img width="763" height="204" alt="Screenshot 2026-06-11 at 23 13 55" src="https://github.com/user-attachments/assets/76b5230a-55f9-466b-906d-c2cc41e298c5" />

After:

<img width="791" height="200" alt="Screenshot 2026-06-11 at 23 11 39" src="https://github.com/user-attachments/assets/f098c952-5a48-4167-b99f-5c8a2c316b8e" />